### PR TITLE
Bumped NVDA version from 1.16.401 to 1.16.402

### DIFF
--- a/layouts/shortcodes/nvdaAddonLink.md
+++ b/layouts/shortcodes/nvdaAddonLink.md
@@ -1,4 +1,4 @@
 {{$title := .Get 0}}
-{{$version := "1.16.401"}}
+{{$version := "1.16.402"}}
 [{{$title}}](https://rhvoice.org/download/RHVoice-{{$version}}.nvda-addon)),
 {{i18n "versionX" (dict "version" $version)}}


### PR DESCRIPTION
# reason for bumping: 
NVDA add-on store stable release.