### PR TITLE
Improve formatting of Linux documentation

### DIFF
--- a/content/en/linux.md
+++ b/content/en/linux.md
@@ -4,9 +4,9 @@ title: "Using RHVoice on Linux"
 
 There are three possible options of installing RHVoice on Linux:
 
-* 1. An up-to-date package distributed through the Snap Store. Below we describe how to install it.
-* 2. One of the packages built for specific Linux distributions. Not all of them will be up-to-date and provide all the voices. See [this page](https://github.com/RHVoice/RHVoice/blob/master/doc/en/Packaging-status.md) for more information.
-* 3. Compiling from source: visit [RHVoice source repository](https://github.com/RHVoice/RHVoice) to learn more.
+1. An up-to-date package distributed through the Snap Store. Below we describe how to install it.
+2. One of the packages built for specific Linux distributions. Not all of them will be up-to-date and provide all the voices. See [this page](https://github.com/RHVoice/RHVoice/blob/master/doc/en/Packaging-status.md) for more information.
+3. Compiling from source: visit [RHVoice source repository](https://github.com/RHVoice/RHVoice) to learn more.
 
 Distribution through the Snap packaging system is preferred by the developers of the core RHVoice engine, as it allows us to easily publish a single up-to-date binary. If you are not familiar with snaps, please visit [this website](https://snapcraft.io/) to learn about them. Your preferred Linux distribution may already have this system preinstalled, or it may be available as a package in its repository.
 
@@ -45,8 +45,11 @@ If you use the Orca screen reader, you will need to manually connect RHVoice to 
 
 The method described below has been tested on Ubuntu. If it doesn't work on your Linux distribution, please let us know.
 
-1. Open the terminal and change directory to `/usr/lib/speech-dispatcher-modules`.
-2. Create a symbolic link to RHVoice's module for Speech Dispatcher:
+1. Open the terminal and change to the directory that contains Speech Dispatcher modules
+```
+cd /usr/lib/speech-dispatcher-modules
+```
+3. Create a symbolic link to RHVoice's module for Speech Dispatcher:
 ```
 sudo ln -s /snap/rhvoice/current/bin/sd_rhvoice
 ```

--- a/content/en/linux.md
+++ b/content/en/linux.md
@@ -45,7 +45,7 @@ If you use the Orca screen reader, you will need to manually connect RHVoice to 
 
 The method described below has been tested on Ubuntu. If it doesn't work on your Linux distribution, please let us know.
 
-1. Open the terminal and change to the directory that contains Speech Dispatcher modules
+1. Open the terminal and change to the directory that contains Speech Dispatcher modules:
 ```
 cd /usr/lib/speech-dispatcher-modules
 ```

--- a/content/en/linux.md
+++ b/content/en/linux.md
@@ -43,13 +43,14 @@ Now let's test if it speaks:
 echo hello|rhvoice.test
 ```
 
-### Use RHVoice with Orca
+## Use RHVoice with Orca
 
 If you use the Orca screen reader, you will need to manually connect RHVoice to Speech Dispatcher, which is the software Orca relies on to work with TTS engines. Unfortunately, we are not aware of any way we could register RHVoice with Speech Dispatcher automatically.
 
-The method described below has been tested on Ubuntu. If it doesn't work on your Linux distribution, please let us know.
+Orca is the default screen reader in Linux distributions such as Ubuntu, Fedora and Debian. The method described below has been tested on Ubuntu. If it doesn't work on your Linux distribution, please let us know.
 
-1. Open the terminal and change to the directory that contains Speech Dispatcher modules:
+1. Install the RHVoice snap and at least one voice as explained in the previous section.
+2. Open the terminal and change to the directory that contains the Speech Dispatcher modules:
 ```
 cd /usr/lib/speech-dispatcher-modules
 ```

--- a/content/en/linux.md
+++ b/content/en/linux.md
@@ -10,6 +10,8 @@ There are three possible options of installing RHVoice on Linux:
 
 Distribution through the Snap packaging system is preferred by the developers of the core RHVoice engine, as it allows us to easily publish a single up-to-date binary. If you are not familiar with snaps, please visit [this website](https://snapcraft.io/) to learn about them. Your preferred Linux distribution may already have this system preinstalled, or it may be available as a package in its repository.
 
+## Install RHVoice snap
+
 The snap only installs the RHVoice TTS engine itself, including the module connecting RHVoice to Speech Dispatcher. Voices need to be installed via the newly implemented built-in command-line voice manager.
 
 Most of the commands described below need to be run as root. We will assume you use the sudo command.
@@ -40,6 +42,8 @@ Now let's test if it speaks:
 ```
 echo hello|rhvoice.test
 ```
+
+### Use RHVoice with Orca
 
 If you use the Orca screen reader, you will need to manually connect RHVoice to Speech Dispatcher, which is the software Orca relies on to work with TTS engines. Unfortunately, we are not aware of any way we could register RHVoice with Speech Dispatcher automatically.
 


### PR DESCRIPTION
Some rather minor changes to the Linux page, for clarity:

- Fix the formatting on the first numbered list
- Add headings for better scannability
- Explain Orca is the default screen reader in popular distributions
- I suggest to be explicit about the command to run to change directory in the Orca instructions. I think we shouldn't assume all users are confortable with the terminal; it's enough that we ask them to use it.

(Full disclosure: I am UX designer for Ubuntu Desktop)

I went through the process just yesterday, it worked well. I'm delighted with the new voice :)